### PR TITLE
Add pod annotations

### DIFF
--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
       labels:
       {{- include "nginx-gateway.selectorLabels" . | nindent 8 }}
       annotations:
-      {{ .Values.nginxGateway.podAnnotations | toYaml | nindent 8 }}
+      {{- if .Values.nginxGateway.podAnnotations }}
+        {{ .Values.nginxGateway.podAnnotations | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.metrics.enable }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.metrics.port }}"

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -15,8 +15,9 @@ spec:
     metadata:
       labels:
       {{- include "nginx-gateway.selectorLabels" . | nindent 8 }}
-      {{- if .Values.metrics.enable }}
       annotations:
+      {{ .Values.nginxGateway.podAnnotations | toYaml | nindent 8 }}
+      {{- if .Values.metrics.enable }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.metrics.port }}"
         {{- if .Values.metrics.secure }}

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -61,8 +61,8 @@ nginxGateway:
     enable: false
 
   ## Additional pod annotations for the NGINX Gateway Fabric pod.
-  podAnnotations: {}
-    # linkerd.io/inject: enabled
+  # podAnnotations:
+  #   linkerd.io/inject: enabled
 
 nginx:
   ## The NGINX image to use

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -60,6 +60,10 @@ nginxGateway:
     ## APIs installed from the experimental channel.
     enable: false
 
+  ## Additional pod annotations for the NGINX Gateway Fabric pod.
+  podAnnotations: {}
+    # linkerd.io/inject: enabled
+
 nginx:
   ## The NGINX image to use
   image:


### PR DESCRIPTION
### Proposed changes

This change refactors pod annotations to allow a user to add arbitrary annotations to pods.

Problem: The helm chart provided no means to annotate pods to allow them to be meshed in a LinkerD service mesh.

Solution: Added a new helm value that allows the user to provide arbitrary pod annotations

Testing:

Template with default values.yaml manifest

```bash
helm template foo . | yq 'select(.kind == "Deployment") | .spec.template.metadata'
```

Result

```yaml
labels:
  app.kubernetes.io/name: nginx-gateway-fabric
  app.kubernetes.io/instance: foo
annotations:
  prometheus.io/scrape: "true"
  prometheus.io/port: "9113"
```

Template with default values and set pod annotations.

```bash
helm template foo . --set nginxGateway.podAnnotations."linkerd\.io/inject"="enabled" | yq 'select(.kind == "Deployment") | .spec.template.metadata'
```

Result

```yaml
labels:
  app.kubernetes.io/name: nginx-gateway-fabric
  app.kubernetes.io/instance: foo
annotations:
  linkerd.io/inject: enabled
  prometheus.io/scrape: "true"
  prometheus.io/port: "9113"
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

